### PR TITLE
Fix gradient flow by computing softmax over full vocabulary

### DIFF
--- a/config/train_avatarl.py
+++ b/config/train_avatarl.py
@@ -10,7 +10,7 @@ experiment_name = "avatarl_pretrain_250M_adamw_big_critic"
 
 # Evaluation and logging intervals
 # Can specify as iterations (int) or epochs (float with 'e' suffix in string, e.g., "0.5e" for every half epoch)
-eval_interval = 50  # Evaluate every N iterations (or set to "1.0e" for every epoch)
+eval_interval = 200  # Evaluate every N iterations (or set to "1.0e" for every epoch)
 log_interval = 10  # Log every N iterations
 eval_iters = 80
 eval_only = False
@@ -41,7 +41,7 @@ learning_rate = 6e-4  # Adjusted for better stability with AvataRL
 
 # Training duration - can specify either max_iters OR max_epochs (not both)
 # If max_epochs is set, max_iters will be calculated automatically based on dataset size
-max_iters = 60  # Maximum training iterations (set to None to use max_epochs instead)
+max_iters = 201  # Maximum training iterations (set to None to use max_epochs instead)
 max_epochs = None  # Maximum training epochs (set to None to use max_iters instead)
 weight_decay = 1e-1
 beta1 = 0.9

--- a/run_timed_training.sh
+++ b/run_timed_training.sh
@@ -6,7 +6,7 @@
 set -e  # Exit on error
 
 echo "=== Timed AvataRL Training Script ==="
-echo "Configuration: 8 GPUs, 600 iterations"
+echo "Configuration: 8 GPUs"
 echo
 
 # Record start time
@@ -17,7 +17,7 @@ echo "Training Start Time: $start_time_readable"
 echo "Timestamp: $start_time"
 echo "----------------------------------------"
 
-# Run AvataRL training with 8 GPUs and 600 iterations
+# Run AvataRL training with 8 GPUs
 # Using torchrun for distributed training across 8 GPUs
 torchrun --standalone --nproc_per_node=8 avatarl.py
 


### PR DESCRIPTION
## Summary
Compute softmax over full vocabulary to fix gradient flow issues

## Changes

### Full Vocabulary Softmax
Previously, we computed softmax only over action tokens (~20-30 tokens), which prevented other tokens from receiving gradients through the partition function. Now we compute softmax over all 65 vocabulary tokens, then gather the action token probabilities.

This ensures proper gradient flow to all model parameters at the cost of higher computation.

### Config Updates
- Increased eval_interval to 200 (reduce evaluation overhead)
- Extended training to 201 iterations for experiments